### PR TITLE
Add KaTeX support, fix RSS and add tags list

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -49,7 +49,7 @@
 	  <div id="home-footer">
 		<p>&copy; {{ now() | date(format="%Y")}}
 		  <a href="{{config.base_url}}">{{config.extra.author.name}}</a>
-		  &#183; <a href="{{get_url(path="posts/index.xml")}}" target="_blank" title="rss">
+		  &#183; <a href="{{config.base_url ~ "/rss.xml"}}" target="_blank" title="rss">
 			<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="feather feather-rss"><path d="M4 11a9 9 0 0 1 9 9"></path><path d="M4 4a16 16 0 0 1 16 16"></path><circle cx="5" cy="19" r="1"></circle></svg>
 		  </a>
 		</p>

--- a/templates/index.html
+++ b/templates/index.html
@@ -59,6 +59,12 @@
 	
 	<script src="{{get_url(path="js/main.js")}}"></script>
 
+	<!-- Math rendering -->
+	<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/katex@0.11.1/dist/katex.min.css" integrity="sha384-zB1R0rpPzHqg7Kpt0Aljp8JPLqbXI3bhnPWROx27a9N0Ll6ZP/+DiW/UqRcLbRjq" crossorigin="anonymous">
+    <script defer src="https://cdn.jsdelivr.net/npm/katex@0.11.1/dist/katex.min.js" integrity="sha384-y23I5Q6l+B6vatafAwxRu/0oK/79VlbSz7Q9aiSZUvyWYIYsd+qj+o24G5ZU2zJz" crossorigin="anonymous"></script>
+    <script defer src="https://cdn.jsdelivr.net/npm/katex@0.11.1/dist/contrib/auto-render.min.js" integrity="sha384-kWPLUVMOks5AQFrykwIup5lo0m3iMkkHrD0uJ4H5cjeGihAutqP0yW0J6dpFiVkI" crossorigin="anonymous"
+        onload="renderMathInElement(document.body, { delimiters: [ {left: '$$', right: '$$', display: true}, {left: '$', right: '$', display: false}, {left: '\\[', right: '\\]', display: true}, {left: '\\(', right: '\\)', display: false}]});"></script>
+
 	{% if config.extra.google_analytics.enable %}
     <!-- Global Site Tag (gtag.js) - Google Analytics -->
     <script async src="https://www.googletagmanager.com/gtag/js?id={{ config.extra.google_analytics.id }}"></script>

--- a/templates/tags/list.html
+++ b/templates/tags/list.html
@@ -1,0 +1,54 @@
+{% extends "index.html" %} {% import "macros.html" as macros %} {% block header
+%}
+<header id="site-header" class="animated slideInUp faster">
+  <div class="hdr-wrapper section-inner">
+    <div class="hdr-left">
+      <div class="site-branding">
+        <a href="{{ config.base_url}}">{{ config.title }}</a>
+      </div>
+      <nav class="site-nav hide-in-mobile">
+        {% for menu_item in config.extra.hermit_menu %}
+        <a href="{{ menu_item.link }}">{{ menu_item.name }}</a>
+        {% endfor %}
+      </nav>
+    </div>
+    <div class="hdr-right hdr-icons">
+      <span class="hdr-social hide-in-mobile">
+        {{ macros::render_social_icons() }}
+      </span>
+      <button id="menu-btn" class="hdr-btn" title="Menu">
+        <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none"
+          stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"
+          class="feather feather-menu">
+          <line x1="3" y1="12" x2="21" y2="12"></line>
+          <line x1="3" y1="6" x2="21" y2="6"></line>
+          <line x1="3" y1="18" x2="21" y2="18"></line>
+        </svg>
+      </button>
+    </div>
+  </div>
+</header>
+<div id="mobile-menu" class="animated fast">
+  <ul>
+    {% for menu_item in config.extra.hermit_menu %}
+    <li><a href="{{ menu_item.link }}">{{ menu_item.name }}</a></li>
+    {% endfor %}
+  </ul>
+</div>
+{% endblock header %} {% block title %} {% endblock title %} {% block main %}
+
+<main class="site-main section-inner thin animated fadeIn faster" style="text-align: center;">
+  {% block content %}
+  {% for tag in terms %}
+  <header class="post-header">
+    <h1 class="post-header__title"><a href="/tags/{{ tag.slug }}">{{ tag.name }}</a></h1>
+    <p class="post-header__info">
+      {{ tag.pages | length }} post{{ tag.pages | length | pluralize }}
+    </p>
+  </header>
+  {% endfor %}
+  {% endblock content %}
+</main>
+
+{% endblock main %} {% block footer %} {{ macros::footer() }} {% endblock footer
+%}


### PR DESCRIPTION
I added KaTeX support to display math formulas according to a discussion [here](https://github.com/getzola/zola/issues/442)

And thanks for @rednithin who fixed RSS feed and added a tags list template. 