### PR TITLE
Add RSS rel link in head

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -22,6 +22,10 @@
   <link rel="stylesheet" href="{{get_url(path="style.css")}}"/>
   <title>{{config.title}}</title>
 
+  {% if config.generate_feed %}
+  <link rel="alternate" type="application/rss+xml" title="RSS" href="{{ get_url(path=config.feed_filename, trailing_slash=false) }}">
+  {% endif %}
+
   <body id="page">
 
 	{% block header %}


### PR DESCRIPTION
This can be useful because most RSS clients can automatically find the site's feed from the rel link in `<head>`.

**Note**: This uses `config.generate_feed` which is a breaking change introduced in Zola 0.11.0, with which the generation of RSS feeds changed. This will not work with previous Zola versions.