### PR TITLE
Fix showing of RSS link in footer

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -48,9 +48,11 @@
 	  {% block footer %}
 	  <div id="home-footer">
 		<p>&copy; {{ now() | date(format="%Y")}}
-		  <a href="{{config.base_url}}">{{config.extra.author.name}}</a>
-		  &#183; <a href="{{config.base_url ~ "/rss.xml"}}" target="_blank" title="rss">
-			<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="feather feather-rss"><path d="M4 11a9 9 0 0 1 9 9"></path><path d="M4 4a16 16 0 0 1 16 16"></path><circle cx="5" cy="19" r="1"></circle></svg>
+      <a href="{{config.base_url}}">{{config.extra.author.name}}</a>
+      {% if config.generate_feed %}
+		  &#183; <a href="{{ get_url(path=config.feed_filename, trailing_slash=false) }}" target="_blank" title="rss">
+      <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="feather feather-rss"><path d="M4 11a9 9 0 0 1 9 9"></path><path d="M4 4a16 16 0 0 1 16 16"></path><circle cx="5" cy="19" r="1"></circle></svg>
+      {% endif %}
 		  </a>
 		</p>
 	  </div>

--- a/templates/macros.html
+++ b/templates/macros.html
@@ -13,8 +13,8 @@
 <footer id="site-footer" class="section-inner thin animated fadeIn faster">
   <p>&copy; {{ now() | date(format="%Y") }} <a href="{{ config.base_url }}">{{ config.extra.author.name }}</a>{{ config.extra.footer_copyright | safe }}</p>
   <p>Made with <a href="https://www.getzola.org" target="_blank" rel="noopener">Zola</a> &#183; Theme <a href="https://github.com/VersBinarii/hermit_zola" target="_blank" rel="noopener">Hermit_Zola</a>
-	{% if config.generate_rss %}
-	&#183; <a href="{{config.base_url ~ "/rss.xml"}}" target="_blank" title="rss"><svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="feather feather-rss"><path d="M4 11a9 9 0 0 1 9 9"></path><path d="M4 4a16 16 0 0 1 16 16"></path><circle cx="5" cy="19" r="1"></circle></svg></a>
+	{% if config.generate_feed %}
+	&#183; <a href="{{ get_url(path=config.feed_filename, trailing_slash=false) }}" target="_blank" title="rss"><svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="feather feather-rss"><path d="M4 11a9 9 0 0 1 9 9"></path><path d="M4 4a16 16 0 0 1 16 16"></path><circle cx="5" cy="19" r="1"></circle></svg></a>
 	{% endif %}
   </p>
 </footer>


### PR DESCRIPTION
Zola 0.11.0 introduced some breaking changes related to RSS generation. The config property for generating rss is now `generate_feed`. Also the filename of the feed can be altered and defaults to an Atom feed.

Anothe fix this pull requests has is to check for the `generate_feed` config value on the home page's footer, which previously would have an RSS link regardless if the site is configured to generate one.

**Note**: This is not gonna be backwards compatible with versions of Zola prior to 0.11.0.