### PR TITLE
use page title over default title where possible

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -20,7 +20,11 @@
     href="{{get_url(path="favicon.ico")}}"
   />
   <link rel="stylesheet" href="{{get_url(path="style.css")}}"/>
+  {% if page.title %}
+  <title>{{page.title}}</title>
+  {% else %}
   <title>{{config.title}}</title>
+  {% endif %}
 
   {% if config.generate_feed %}
   <link rel="alternate" type="application/rss+xml" title="RSS" href="{{ get_url(path=config.feed_filename, trailing_slash=false) }}">


### PR DESCRIPTION
Google uses the page title heavily when indexing, it's better to use the page title for specific posts than the general title.