### PR TITLE
use section title instead of hardcoded title 'Posts'

### DIFF
--- a/templates/section.html
+++ b/templates/section.html
@@ -51,7 +51,7 @@
 {% endblock header %} {% block title %} {% endblock title %} {% block main %}
 
 <main class="site-main section-inner thin animated fadeIn faster">
-  <h1>Posts</h1>
+  <h1>{% section.title %}</h1>
   {% for year, pages in section.pages | group_by(attribute="year") %}
   <div class="posts-group">
     <div class="post-year">{{ year }}</div>


### PR DESCRIPTION
Hey, this is just a tiny change. I want to use a different section title other than "Posts" for my page. In the `posts/_index.html` there is even a `title` variable set which can replace the hardcoded text so this shouldn't be breaking.