### PR TITLE
Fix menu link urls in tags templates

### DIFF
--- a/templates/tags/list.html
+++ b/templates/tags/list.html
@@ -8,7 +8,7 @@
       </div>
       <nav class="site-nav hide-in-mobile">
         {% for menu_item in config.extra.hermit_menu %}
-        <a href="{{ menu_item.link }}">{{ menu_item.name }}</a>
+        <a href="{{ config.base_url ~ menu_item.link }}">{{ menu_item.name }}</a>
         {% endfor %}
       </nav>
     </div>
@@ -31,7 +31,7 @@
 <div id="mobile-menu" class="animated fast">
   <ul>
     {% for menu_item in config.extra.hermit_menu %}
-    <li><a href="{{ menu_item.link }}">{{ menu_item.name }}</a></li>
+    <li><a href="{{ config.base_url ~ menu_item.link }}">{{ menu_item.name }}</a></li>
     {% endfor %}
   </ul>
 </div>

--- a/templates/tags/single.html
+++ b/templates/tags/single.html
@@ -8,7 +8,7 @@
       </div>
       <nav class="site-nav hide-in-mobile">
         {% for menu_item in config.extra.hermit_menu %}
-        <a href="{{ menu_item.link }}">{{ menu_item.name }}</a>
+        <a href="{{ config.base_url ~ menu_item.link }}">{{ menu_item.name }}</a>
         {% endfor %}
       </nav>
     </div>
@@ -40,7 +40,7 @@
 <div id="mobile-menu" class="animated fast">
   <ul>
     {% for menu_item in config.extra.hermit_menu %}
-    <li><a href="{{ menu_item.link }}">{{ menu_item.name }}</a></li>
+    <li><a href="{{ config.base_url ~ menu_item.link }}">{{ menu_item.name }}</a></li>
     {% endfor %}
   </ul>
 </div>


### PR DESCRIPTION
The template should prepend config.base_url to each menu link url.

Closes #31 